### PR TITLE
Pasted Tailor-WP5 from global Tailor file.

### DIFF
--- a/tailor-wp5.bib
+++ b/tailor-wp5.bib
@@ -1,19 +1,38 @@
+@inproceedings{aaai2021bg,
+ author = {Bonet, Blai and Geffner, Hector},
+ booktitle = {{AAAI}},
+ keywords = {WP5,A-level,Outside-Europe},
+ title = {General Policies, Representations, and Planning Width},
+ url_paper = {https://arxiv.org/pdf/2012.08033.pdf},
+ year = {2021}
+}
+
 @inproceedings{aaai2021dmfp,
  author = {Luisa R. de A. Santos and
 Felipe Meneguzzi and
 Ramon {Fraga Pereira} and
 Andre G. Pereira},
  booktitle = {{AAAI}},
- keywords = {Task-5.3-WP5},
+ keywords = {WP5,A-level,Outside-Europe},
  title = {An LP-Based Approach for Goal Recognition as Planning},
  url_paper = {https://whitemech.github.io/papers/2021/aaai2021dmfp.pdf},
+ year = {2021}
+}
+
+@inproceedings{aaai2021gbg,
+ author = {Franc{\`e}s, Guillem and Bonet, Blai and Geffner, Hector},
+ booktitle = {{AAAI}},
+ keywords = {WP5,A-level,Outside-Europe},
+ pages = {11801--11808},
+ title = {Learning General Planning Policies from Small Examples Without Supervision},
+ url_paper = {https://arxiv.org/pdf/2101.00692.pdf},
  year = {2021}
 }
 
 @inproceedings{aaai2021lstgs,
  author = {Leonardo Lamanna and Luciano Serafini and Alfonso E. Gerevini and Alessandro Saetti and Paolo Traverso },
  booktitle = {{AAAI}},
- keywords = {Task-5.4-WP5},
+ keywords = {WP5,A-level,2+TAILOR-Partners},
  title = {On-line Learning of Planning Domains from Sensor Data in {PAL}: Scaling up to Large State Spaces},
  year = {2021}
 }
@@ -21,7 +40,7 @@ Andre G. Pereira},
 @inproceedings{aaai2021mv,
  author = {Andrea Micheli and Alessandro Valentini},
  booktitle = {{AAAI}},
- keywords = {Task-5.3-WP5},
+ keywords = {WP5,A-level},
  title = {Synthesis of Search Heuristics for Temporal Planning via Reinforcement Learning},
  year = {2021}
 }
@@ -29,7 +48,7 @@ Andre G. Pereira},
 @inproceedings{aaai2021skh,
  author = {Jendrik Seipp and Thomas Keller and Malte Helmert},
  booktitle = {{AAAI}},
- keywords = {Task-5.3-WP5},
+ keywords = {WP5,2+TAILOR-Partners,A-level},
  title = {Saturated Post-hoc Optimization for Classical Planning},
  url_paper = {https://ai.dmi.unibas.ch/papers/seipp-et-al-aaai2021.pdf},
  url_poster = {https://ai.dmi.unibas.ch/papers/seipp-et-al-aaai2021-poster.pdf},
@@ -40,7 +59,7 @@ Andre G. Pereira},
 @inproceedings{aaai2021ssta,
  author = {Alejandro Su{\'a}rez-Hern{\'a}ndez and Javier Segovia-Aguas and Carme Torras and Guillem Aleny{\`a}},
  booktitle = {{AAAI}},
- keywords = {Task-5.2-WP5},
+ keywords = {WP5,A-level},
  title = {Online Action Recognition},
  url_code = {https://github.com/sprkrd/sat_strips_learn},
  url_paper = {https://arxiv.org/pdf/2012.07464.pdf},
@@ -55,7 +74,7 @@ Yingying Shi and
 Geguang Pu and
 Moshe Vardi},
  booktitle = {{AAAI}},
- keywords = {Task-5.1-WP5},
+ keywords = {WP5,A-level,Outside-Europe},
  title = {On-the-fly Synthesis for {LTL} over Finite Traces},
  url_paper = {https://whitemech.github.io/papers/2021/aaai2021xlzspv.pdf},
  year = {2021}
@@ -64,7 +83,7 @@ Moshe Vardi},
 @inproceedings{aaai2022cphf,
  author = {Augusto B. Corr{\^e}a and Florian Pommerening and Malte Helmert and Guillem Franc{\`e}s},
  booktitle = {AAAI},
- keywords = {Task-5.3-WP5},
+ keywords = {WP5,2+TAILOR-Partners,A-level},
  pages = {9716--9723},
  title = {The {FF} Heuristic for Lifted Classical Planning},
  url_paper = {https://ai.dmi.unibas.ch/papers/correa-et-al-aaai2022.pdf},
@@ -72,17 +91,13 @@ Moshe Vardi},
 }
 
 @inproceedings{aaai2022fs,
- author = {Patrick Ferber and
-Jendrik Seipp},
+ author = {Patrick Ferber, Jendrik Seipp},
  booktitle = {{AAAI}},
- keywords = {Task-5.3-WP5},
- pages = {9741--9749},
+ keywords = {WP5,A-level},
+ note = {To appear},
  publisher = {{AAAI} Press},
  title = {Explainable Planner Selection for Classical Planning},
- url_code = {https://zenodo.org/record/5767692},
  url_paper = {https://ai.dmi.unibas.ch/papers/ferber-seipp-aaai2022.pdf},
- url_poster = {https://ai.dmi.unibas.ch/papers/ferber-seipp-aaai2022-poster.pdf},
- url_slides = {https://ai.dmi.unibas.ch/papers/ferber-seipp-aaai2022-slides.pdf},
  year = {2022}
 }
 
@@ -93,7 +108,7 @@ Arnaud Gotlieb and
 Nadjib Lazaar and
 Helge Spieker},
  booktitle = {{AAAI}},
- keywords = { Task-5.3-WP5, WP4},
+ keywords = {WP5,WP4,A-level},
  title = {{GEQCA:} Generic Qualitative Constraint Acquisition},
  url_paper = {https://ojs.aaai.org/index.php/AAAI/article/view/20282},
  year = {2022}
@@ -102,9 +117,9 @@ Helge Spieker},
 @inproceedings{aaai22cmp,
  author = {Francesco Chiariello and {Fabrizio Maria} Maggi and Fabio Patrizi},
  booktitle = {{AAAI}},
- keywords = {Task-5.1-WP5},
+ keywords = {WP5,A-level},
+ note = {To appear},
  title = {{ASP}-Based Declarative Process Mining},
- url_paper = {https://whitemech.github.io/papers/2022/aaai2022cmp.pdf},
  year = {2022}
 }
 
@@ -113,7 +128,7 @@ Helge Spieker},
 Ramon {Fraga Pereira} and
 Felipe Meneguzzi},
  booktitle = {{AAMAS}},
- keywords = {Task-5.3-WP5},
+ keywords = {WP5,A-level,Outside-Europe},
  title = {Combining {LSTMs} and Symbolic Approaches for Robust Plan Recognition},
  url_paper = {https://whitemech.github.io/papers/2021/aamas2021rfm.pdf},
  year = {2021}
@@ -122,7 +137,7 @@ Felipe Meneguzzi},
 @article{AGHHKNPSW21,
  author = {Alessandro Abate and Julian Gutierrez and Lewis Hammond and Paul Harrenstein and Marta Kwiatkowska and Muhammad Najib and Giuseppe Perelli and Thomas Steeples and {Michael J.} Wooldridge},
  journal = {Appl. Intell.},
- keywords = {Task-5.1-WP5},
+ keywords = {WP5},
  number = {9},
  pages = {6569--6584},
  title = {Rational verification: game-theoretic verification of multi-agent systems},
@@ -132,20 +147,23 @@ Felipe Meneguzzi},
 
 @article{aij2020chmmpr,
  author = {Martin C. Cooper and Andreas Herzig and Faustine Maffre and Fr{\'e}d{\'e}ric Maris and Elise Perrotin and Pierre R{\'e}gnier},
+ doi = {10.1016/j.artint.2020.103437},
  journal = {Artificial Intelligence},
- keywords = {Task-5.1-WP5},
+ keywords = {WP5,WP6,A-level},
  pages = {103437},
  publisher = {Elsevier},
  title = {A Lightweight Epistemic Logic and its Application to Planning},
- year = {2020}
+ url = {https://doi.org/10.1016/j.artint.2020.103437},
+ volume = {298},
+ year = {2021}
 }
 
 @article{aij2021dflps,
  author = {{De Giacomo}, Giuseppe and Felli, Paolo and Logan, Brian and Patrizi, Fabio and Sardi{\~{n}}a, Sebastian},
  journal = {Artificial Intelligence},
- keywords = {Task-5.1-WP5},
+ keywords = {WP5,A-level,2+TAILOR-Partners,Outside-Europe},
  title = {Situation Calculus for Controller Synthesis in Manufacturing Systems with First-Order State Representation},
- year = {2021}
+ year = {2022}
 }
 
 @article{aij2022rkch,
@@ -153,7 +171,7 @@ Felipe Meneguzzi},
  doi = {https://doi.org/10.1016/j.artint.2022.103668},
  issn = {0004-3702},
  journal = {Artificial Intelligence},
- keywords = {Task-5.1-WP5},
+ keywords = {WP5,A-level},
  pages = {103668},
  title = {The Delay and Window Size Problems in Rule-Based Stream Reasoning},
  year = {2022}
@@ -162,7 +180,7 @@ Felipe Meneguzzi},
 @inproceedings{alechina:kr2022,
  author = {Natasha Alechina and Giuseppe {De Giacomo} and Brian Logan and Giuseppe Perelli},
  booktitle = {KR},
- keywords = {Task-5.1-WP5},
+ keywords = {WP5,A-level},
  title = {Automatic Synthesis of Dynamic Norms for Multi-Agent Systems},
  year = {2022}
 }
@@ -171,7 +189,7 @@ Felipe Meneguzzi},
  archiveprefix = {arXiv},
  author = {Damiano Brunori and Stefania Colonnese and Francesca Cuomo and Luca Iocchi},
  eprint = {2105.05094},
- keywords = {Task-5.2-WP5},
+ keywords = {WP5},
  primaryclass = {cs.LG},
  title = {A Reinforcement Learning Environment for Multi-Service {UAV}-enabled Wireless Systems},
  url_paper = {https://whitemech.github.io/papers/2021/arxiv2021bcci.pdf},
@@ -184,7 +202,7 @@ Felipe Meneguzzi},
 Giuseppe Perelli},
  eprint = {2102.11184},
  journal = {CoRR},
- keywords = {Task-5.1-WP5},
+ keywords = {WP5},
  title = {Behavioral {QLTL}},
  url_paper = {https://whitemech.github.io/papers/2021/arxiv2021dp.pdf},
  volume = {abs/2102.11184},
@@ -196,7 +214,7 @@ Giuseppe Perelli},
  author = {{Fraga Pereira}, Ramon and Fuggitti, Francesco and {De Giacomo}, Giuseppe},
  eprint = {2103.11692},
  journal = {CoRR},
- keywords = {Task-5.1-WP5},
+ keywords = {WP5},
  month = {March},
  primaryclass = {cs.AI},
  title = {Recognizing {LTLf}/{PLTLf} Goals in Fully Observable Non-Deterministic Domain Models},
@@ -210,7 +228,7 @@ Giuseppe Perelli},
  author = {Kin {Max Gusmao} and Ramon {Fraga Pereira} and Andre {Grahl Pereira} and Felipe Meneguzzi},
  eprint = {2102.11791},
  journal = {CoRR},
- keywords = {Task-5.3-WP5},
+ keywords = {WP5,Outside-Europe},
  title = {Inferring Agents Preferences as Priors for Probabilistic Goal Recognition},
  url_paper = {https://whitemech.github.io/papers/2021/arxiv2021mfgm.pdf},
  volume = {abs/2102.11791},
@@ -222,7 +240,7 @@ Giuseppe Perelli},
 Marco Favorito and
 Francesco Fuggitti},
  journal = {CoRR},
- keywords = {Task-5.1-WP5},
+ keywords = {WP5},
  title = {Planning for Temporally Extended Goals in Pure-Past Linear Temporal
 Logic: {A} Polynomial Reduction to Standard Planning},
  url_paper = {https://arxiv.org/pdf/2204.09960.pdf},
@@ -230,69 +248,172 @@ Logic: {A} Polynomial Reduction to Standard Planning},
  year = {2022}
 }
 
-@inproceedings{bonet:aaai2021,
- author = {Bonet, Blai and Geffner, Hector},
- booktitle = {{AAAI}},
- keywords = {Task-5.2-WP5},
- title = {General Policies, Representations, and Planning Width},
- url_paper = {https://arxiv.org/pdf/2012.08033.pdf},
- year = {2021}
-}
-
 @inproceedings{caise2022ammpr,
  author = {Anti Alman and {Fabrizio Maria} Maggi and Marco Montali and Fabio Patrizi and Andrey Rivkin},
  booktitle = {{CAISE}},
- keywords = {Task-5.1-WP5},
+ keywords = {WP5},
  note = {To appear},
  title = {Multi-Model Monitoring Framework for Hybrid Process Specifications},
  year = {2022}
+}
+
+@article{CIMA2023103976,
+ author = {Gianluca Cima and Antonella Poggi and Maurizio Lenzerini},
+ doi = {https://doi.org/10.1016/j.artint.2023.103976},
+ issn = {0004-3702},
+ journal = {Artificial Intelligence},
+ keywords = {WP4,WP5,A-level},
+ pages = {103976},
+ title = {The notion of Abstraction in Ontology-based Data Management},
+ url = {https://www.sciencedirect.com/science/article/pii/S0004370223001224},
+ url_paper = {https://www.sciencedirect.com/science/article/pii/S0004370223001224},
+ volume = {323},
+ year = {2023}
+}
+
+@inproceedings{conf/aistats/Bourel23,
+ author = {Hippolyte Bourel and Anders Jonsson and Odalric-Ambrym Maillard and Mohammad Sadegh Talebi},
+ booktitle = {International Conference on Artificial Intelligence and Statistics (AISTATS)},
+ keywords = {WP5},
+ pages = {4114–4146},
+ title = {{Exploration in Reward Machines with Low Regret}},
+ url_paper = {https://proceedings.mlr.press/v206/bourel23a/bourel23a.pdf},
+ year = {2023}
+}
+
+@inproceedings{conf/icml/Furelos23,
+ author = {Daniel Furelos-Blanco and Mark Law and Anders Jonsson and Krysia Broda and Alessandra Russo},
+ booktitle = {International Conference on Machine Learning (ICML)},
+ keywords = {WP5},
+ pages = {10494–10541},
+ title = {{Hierarchies of reward machines}},
+ url_paper = {https://proceedings.mlr.press/v202/furelos-blanco23a/furelos-blanco23a.pdf},
+ year = {2023}
+}
+
+@inproceedings{DBLP:conf/aaai/0002GFIP23,
+ author = {Roberto Cipollone and
+Giuseppe De Giacomo and
+Marco Favorito and
+Luca Iocchi and
+Fabio Patrizi},
+ bibsource = {dblp computer science bibliography, https://dblp.org},
+ biburl = {https://dblp.org/rec/conf/aaai/0002GFIP23.bib},
+ booktitle = {Thirty-Seventh {AAAI} Conference on Artificial Intelligence, {AAAI}
+2023},
+ doi = {10.1609/aaai.v37i6.25881},
+ editor = {Brian Williams and
+Yiling Chen and
+Jennifer Neville},
+ keywords = {WP5,A-level},
+ pages = {7227--7234},
+ publisher = {{AAAI} Press},
+ timestamp = {Mon, 04 Sep 2023 16:50:21 +0200},
+ title = {Exploiting Multiple Abstractions in Episodic {RL} via Reward Shaping},
+ url = {https://doi.org/10.1609/aaai.v37i6.25881},
+ url_paper = {https://doi.org/10.1609/aaai.v37i6.25881},
+ year = {2023}
+}
+
+@inproceedings{DBLP:conf/aaai/CimaCLP22,
+ author = {Gianluca Cima and
+Marco Console and
+Maurizio Lenzerini and
+Antonella Poggi},
+ bibsource = {dblp computer science bibliography, https://dblp.org},
+ biburl = {https://dblp.org/rec/conf/aaai/CimaCLP22.bib},
+ booktitle = {Thirty-Sixth {AAAI} Conference on Artificial Intelligence, {AAAI}
+2022},
+ doi = {10.1609/aaai.v36i5.20495},
+ keywords = {WP4,WP5,A-level},
+ pages = {5556--5563},
+ publisher = {{AAAI} Press},
+ timestamp = {Mon, 04 Sep 2023 16:50:23 +0200},
+ title = {Monotone Abstractions in Ontology-Based Data Management},
+ url = {https://doi.org/10.1609/aaai.v36i5.20495},
+ url_paper = {https://doi.org/10.1609/aaai.v36i5.20495},
+ year = {2022}
+}
+
+@inproceedings{DBLP:conf/aaai/CimaCLP23,
+ author = {Gianluca Cima and
+Marco Console and
+Maurizio Lenzerini and
+Antonella Poggi},
+ bibsource = {dblp computer science bibliography, https://dblp.org},
+ biburl = {https://dblp.org/rec/conf/aaai/CimaCLP23.bib},
+ booktitle = {Thirty-Seventh {AAAI} Conference on Artificial Intelligence, {AAAI}
+2023},
+ doi = {10.1609/aaai.v37i5.25773},
+ editor = {Brian Williams and
+Yiling Chen and
+Jennifer Neville},
+ keywords = {WP4,WP5,A-level},
+ pages = {6280--6288},
+ publisher = {{AAAI} Press},
+ timestamp = {Mon, 04 Sep 2023 16:50:23 +0200},
+ title = {Epistemic Disjunctive Datalog for Querying Knowledge Bases},
+ url = {https://doi.org/10.1609/aaai.v37i5.25773},
+ url_paper = {https://doi.org/10.1609/aaai.v37i5.25773},
+ year = {2023}
+}
+
+@inproceedings{DBLP:conf/aaai/Geffner22,
+ author = {Hector Geffner},
+ booktitle = {{AAAI}},
+ keywords = {WP5,A-level},
+ pages = {12326--12333},
+ publisher = {{AAAI} Press},
+ title = {Target Languages (vs. Inductive Biases) for Learning to Act and Plan},
+ year = {2022}
+}
+
+@inproceedings{DBLP:conf/bpm/ChiarielloPM23,
+ author = {Francesco Chiariello and
+Fabrizio Maria Maggi and
+Fabio Patrizi},
+ booktitle = {Proceedings of the Best Dissertation Award, Doctoral Consortium, and
+Demonstration {\&} Resources Forum at {BPM} 2023},
+ editor = {Dirk Fahland and
+Andr{\'{e}}s Jim{\'{e}}nez{-}Ram{\'{\i}}rez and
+Akhil Kumar and
+Jan Mendling and
+Brian T. Pentland and
+Stefanie Rinderle{-}Ma and
+Tijs Slaats and
+Johan Versendaal and
+Barbara Weber and
+Mathias Weske and
+Karolin Winter},
+ keywords = {WP5},
+ pages = {127--131},
+ publisher = {CEUR-WS.org},
+ series = {{CEUR} Workshop Proceedings},
+ title = {From {LTL} on Process Traces to Finite-state Automata},
+ url = {https://ceur-ws.org/Vol-3469/paper-23.pdf},
+ url_paper = {https://ceur-ws.org/Vol-3469/paper-23.pdf},
+ volume = {3469},
+ year = {2023}
 }
 
 @inproceedings{DBLP:conf/cikm/CimaCL21,
  author = {Gianluca Cima and
 Federico Croce and
 Maurizio Lenzerini},
- booktitle = {{CIKM}},
+ booktitle = {{CIKM} '21: The 30th {ACM} International Conference on Information
+and Knowledge Management, Virtual Event, Queensland, Australia, November
+1 - 5, 2021},
  doi = {10.1145/3459637.3482466},
- keywords = {WP4,Task-5.1-WP5},
+ editor = {Gianluca Demartini and
+Guido Zuccon and
+J. Shane Culpepper and
+Zi Huang and
+Hanghang Tong},
+ keywords = {WP4,WP5,A-level},
  pages = {271--280},
  publisher = {{ACM}},
  title = {Query Definability and Its Approximations in Ontology-based Data Management},
  url = {https://doi.org/10.1145/3459637.3482466},
- year = {2021}
-}
-
-@inproceedings{DBLP:conf/clar/HerzigY21,
- author = {Andreas Herzig and
-Antonio Yuste{-}Ginel},
- booktitle = {Logic and Argumentation - 4th International Conference, {CLAR} 2021,
-Hangzhou, China, October 20-22, 2021, Proceedings},
- doi = {10.1007/978-3-030-89391-0\_11},
- keywords = {WP6},
- pages = {190--208},
- publisher = {Springer},
- series = {Lecture Notes in Computer Science},
- title = {Abstract Argumentation with Qualitative Uncertainty: An Analysis in
-Dynamic Logic},
- url = {https://doi.org/10.1007/978-3-030-89391-0\_11},
- volume = {13040},
- year = {2021}
-}
-
-@inproceedings{DBLP:conf/clar/HerzigY21,
- author = {Andreas Herzig and
-Antonio Yuste{-}Ginel},
- booktitle = {Logic and Argumentation - 4th International Conference, {CLAR} 2021,
-Hangzhou, China, October 20-22, 2021, Proceedings},
- doi = {10.1007/978-3-030-89391-0\_11},
- keywords = {WP6},
- pages = {190--208},
- publisher = {Springer},
- series = {Lecture Notes in Computer Science},
- title = {Abstract Argumentation with Qualitative Uncertainty: An Analysis in
-Dynamic Logic},
- url = {https://doi.org/10.1007/978-3-030-89391-0\_11},
- volume = {13040},
  year = {2021}
 }
 
@@ -302,7 +423,7 @@ Bastien Maubert and
 Aniello Murano and
 Laurent Perrussel},
  booktitle = {{ICTCS}},
- keywords = {Task-5.1-WP5},
+ keywords = {WP5},
  publisher = {CEUR-WS.org},
  series = {{CEUR} Workshop Proceedings},
  title = {Synthesis of Mechanisms with Strategy Logic (short paper)},
@@ -313,7 +434,7 @@ Laurent Perrussel},
  author = {Shufang Zhu and
 Giuseppe {De Giacomo}},
  booktitle = {{IJCAI}},
- keywords = {Task-5.1-WP5},
+ keywords = {WP5,A-level},
  pages = {2783--2789},
  publisher = {ijcai.org},
  title = {Synthesis of Maximally Permissive Strategies for LTLf Specifications},
@@ -326,7 +447,7 @@ Giuseppe {De Giacomo} and
 Sasha Rubin and
 Florian Zuleger},
  booktitle = {{IJCAI}},
- keywords = {Task-5.1-WP5},
+ keywords = {WP5,A-level,Outside-Europe},
  pages = {2525--2531},
  publisher = {ijcai.org},
  title = {Beyond Strong-Cyclic: Doing Your Best in Stochastic Environments},
@@ -339,11 +460,35 @@ Giuseppe {De Giacomo} and
 Marco Montali and
 Fabio Patrizi},
  booktitle = {{IJCAI}},
- keywords = {Task-5.1-WP5},
+ keywords = {WP5,A-level},
  pages = {2553--2560},
  publisher = {ijcai.org},
  title = {Verification and Monitoring for First-Order {LTL} with Persistence-Preserving
 Quantification over Finite and Infinite Traces},
+ year = {2022}
+}
+
+@inproceedings{DBLP:conf/ijcai/CalvaneseGMP22a,
+ author = {Diego Calvanese and
+Giuseppe De Giacomo and
+Marco Montali and
+Fabio Patrizi},
+ booktitle = {Proceedings of the Workshop on Process Management in the {AI} Era
+{(PMAI 2022)} co-located with {(IJCAI-ECAI 2022)}},
+ editor = {Giuseppe De Giacomo and
+Antonella Guzzo and
+Marco Montali and
+Lior Limonad and
+Fabiana Fournier and
+Tagatha Chakraborti},
+ keywords = {WP5},
+ pages = {93--96},
+ publisher = {CEUR-WS.org},
+ series = {{CEUR} Workshop Proceedings},
+ title = {Verification of Generic, Relational Transition Systems},
+ url = {https://ceur-ws.org/Vol-3310/paper16.pdf},
+ url_paper = {https://ceur-ws.org/Vol-3310/paper16.pdf},
+ volume = {3310},
  year = {2022}
 }
 
@@ -355,12 +500,25 @@ Moshe Y. Vardi and
 Shengping Xiao and
 Shufang Zhu},
  booktitle = {{IJCAI}},
- keywords = {Task-5.1-WP5},
+ keywords = {WP5,A-level,Outside-Europe},
  pages = {2591--2598},
  publisher = {ijcai.org},
  title = {LTLf Synthesis as {AND-OR} Graph Search: Knowledge Compilation at
 Work},
  year = {2022}
+}
+
+@inproceedings{DBLP:conf/ijcai/HaberingHL21,
+ author = {Daniel Habering and
+Till Hofmann and
+Gerhard Lakemeyer},
+ booktitle = {{IJCAI}},
+ keywords = {WP5,A-level},
+ pages = {1908--1914},
+ publisher = {ijcai.org},
+ title = {Using Platform Models for a Guided Explanatory Diagnosis Generation
+for Mobile Robots},
+ year = {2021}
 }
 
 @inproceedings{DBLP:conf/ijcai/HerzigLP22,
@@ -372,12 +530,24 @@ Artificial Intelligence, {IJCAI} 2022, Vienna, Austria, 23-29 July
 2022},
  doi = {10.24963/ijcai.2022/367},
  editor = {Luc De Raedt},
- keywords = { Task-5.1-WP5},
+ keywords = {WP5,A-level},
  pages = {2648--2654},
  publisher = {ijcai.org},
  title = {A Computationally Grounded Logic of 'Seeing-to-it-that'},
  url = {https://doi.org/10.24963/ijcai.2022/367},
  year = {2022}
+}
+
+@inproceedings{DBLP:conf/ijcai/LiuL21,
+ author = {Daxin Liu and
+Gerhard Lakemeyer},
+ booktitle = {{IJCAI}},
+ keywords = {WP5,A-level},
+ pages = {1951--1958},
+ publisher = {ijcai.org},
+ title = {Reasoning about Beliefs and Meta-Beliefs by Regression in an Expressive
+Probabilistic Action Logic},
+ year = {2021}
 }
 
 @inproceedings{DBLP:conf/ijcai/MittelmannMMP22,
@@ -386,24 +556,23 @@ Bastien Maubert and
 Aniello Murano and
 Laurent Perrussel},
  booktitle = {{IJCAI}},
- keywords = {Task-5.1-WP5},
+ keywords = {WP5,A-level},
  pages = {426--432},
  publisher = {ijcai.org},
  title = {Automated Synthesis of Mechanisms},
  year = {2022}
 }
 
-@inproceedings{DBLP:conf/jelia/MittelmannHP21,
- author = {Munyque Mittelmann and
-Andreas Herzig and
-Laurent Perrussel},
- booktitle = {{JELIA}},
- keywords = {WP6},
- pages = {116--130},
- publisher = {Springer},
- series = {Lecture Notes in Computer Science},
- title = {Epistemic Reasoning About Rationality and Bids in Auctions},
- volume = {12678},
+@inproceedings{DBLP:conf/ijcai/ViehmannHL21,
+ author = {Tarik Viehmann and
+Till Hofmann and
+Gerhard Lakemeyer},
+ booktitle = {{IJCAI}},
+ keywords = {WP5,A-level},
+ pages = {2083--2089},
+ publisher = {ijcai.org},
+ title = {Transforming Robotic Plans with Timed Automata to Solve Temporal Platform
+Constraints},
  year = {2021}
 }
 
@@ -411,24 +580,71 @@ Laurent Perrussel},
  author = {Shufang Zhu and
 Giuseppe {De Giacomo}},
  booktitle = {{KR}},
- keywords = {Task-5.1-WP5},
+ keywords = {WP5,A-level},
  title = {Act for Your Duties but Maintain Your Rights},
  year = {2022}
 }
 
-@inproceedings{DBLP:conf/socs/SieversGT22,
- author = {Silvan Sievers and
-Daniel Gnad and
-{\'{A}}lvaro Torralba},
- booktitle = {Proceedings of the Fifteenth International Symposium on Combinatorial
-Search, {SOCS} 2022, Vienna, Austria, July 21-23, 2022},
- editor = {Luk{\'{a}}s Chrpa and
-Alessandro Saetti},
- keywords = {Task-5.3-WP5},
- pages = {180--189},
- publisher = {{AAAI} Press},
- title = {Additive Pattern Databases for Decoupled Search},
- url_paper = {https://rlplab.com/papers/sievers-et-al-socs2022.pdf},
+@inproceedings{DBLP:conf/kr/HerzigMP21,
+ author = {Andreas Herzig and
+Fr{\'{e}}d{\'{e}}ric Maris and
+Elise Perrotin},
+ booktitle = {Proceedings of the 18th International Conference on Principles of
+Knowledge Representation and Reasoning, {KR} 2021, Online event, November
+3-12, 2021},
+ doi = {10.24963/kr.2021/68},
+ keywords = {WP5,A-level},
+ pages = {676--680},
+ title = {A Dynamic Epistemic Logic with Finite Iteration and Parallel Composition},
+ url = {https://proceedings.kr.org/2021/68/kr2021-0068-herzig-et-al.pdf},
+ year = {2021}
+}
+
+@inproceedings{DBLP:conf/sac/TrapassoSIP23,
+ author = {Alessandro Trapasso and
+Sofia Santilli and
+Luca Iocchi and
+Fabio Patrizi},
+ booktitle = {Proceedings of the 38th {ACM/SIGAPP} Symposium on Applied Computing,
+{SAC} 2023, Tallinn, Estonia, March 27-31, 2023},
+ doi = {10.1145/3555776.3577753},
+ editor = {Jiman Hong and
+Maart Lanperne and
+Juw Won Park and
+Tom{\'{a}}s Cern{\'{y}} and
+Hossain Shahriar},
+ keywords = {WP5},
+ pages = {816--823},
+ publisher = {{ACM}},
+ title = {A formalization of multi-agent planning with explicit agent representation},
+ url = {https://doi.org/10.1145/3555776.3577753},
+ url_paper = {https://doi.org/10.1145/3555776.3577753},
+ year = {2023}
+}
+
+@inproceedings{DBLP:conf/sebd/CimaCLP22,
+ author = {Gianluca Cima and
+Marco Console and
+Maurizio Lenzerini and
+Antonella Poggi},
+ bibsource = {dblp computer science bibliography, https://dblp.org},
+ biburl = {https://dblp.org/rec/conf/sebd/CimaCLP22.bib},
+ booktitle = {Proceedings of the 30th Italian Symposium on Advanced Database Systems,
+{SEBD} 2022, Tirrenia (PI), Italy, June 19-22, 2022},
+ editor = {Giuseppe Amato and
+Valentina Bartalesi and
+Devis Bianchini and
+Claudio Gennaro and
+Riccardo Torlone},
+ keywords = {WP4,WP5},
+ pages = {522--529},
+ publisher = {CEUR-WS.org},
+ series = {{CEUR} Workshop Proceedings},
+ timestamp = {Fri, 10 Mar 2023 16:23:21 +0100},
+ title = {Investigating Monotone Abstractions},
+ url = {https://ceur-ws.org/Vol-3194/paper61.pdf},
+ url_paper = {https://ceur-ws.org/Vol-3194/paper61.pdf},
+ volume = {3194},
  year = {2022}
 }
 
@@ -438,12 +654,33 @@ Lorenzo Lepore and
 Antonella Poggi},
  doi = {10.1016/j.artint.2020.103432},
  journal = {Artificial Intelligence},
- keywords = {WP4,Task-5.1-WP5},
+ keywords = {WP4,WP5,A-level},
  pages = {103432},
  title = {Metamodeling and metaquerying in {OWL} 2 {QL}},
  url = {https://doi.org/10.1016/j.artint.2020.103432},
  volume = {292},
  year = {2021}
+}
+
+@article{DBLP:journals/is/AgostinelliCMMP23,
+ author = {Simone Agostinelli and
+Francesco Chiariello and
+Fabrizio Maria Maggi and
+Andrea Marrella and
+Fabio Patrizi},
+ bibsource = {dblp computer science bibliography, https://dblp.org},
+ biburl = {https://dblp.org/rec/journals/is/AgostinelliCMMP23.bib},
+ doi = {10.1016/j.is.2023.102180},
+ journal = {Inf. Syst.},
+ keywords = {WP5},
+ pages = {102180},
+ timestamp = {Mon, 26 Jun 2023 20:54:32 +0200},
+ title = {Process mining meets model learning: Discovering deterministic finite
+state automata from event logs for business process analysis},
+ url = {https://doi.org/10.1016/j.is.2023.102180},
+ url_paper = {https://doi.org/10.1016/j.is.2023.102180},
+ volume = {114},
+ year = {2023}
 }
 
 @article{DBLP:journals/jdiq/GeislerVCLGJLMO22,
@@ -461,7 +698,7 @@ Barbara Pernici and
 Jakob Rehof},
  doi = {10.1145/3467022},
  journal = {{ACM} J. Data Inf. Qual.},
- keywords = {WP4,Task-5.1-WP5},
+ keywords = {WP4,WP5,A-level},
  number = {1},
  pages = {3:1--3:12},
  title = {Knowledge-Driven Data Ecosystems Toward Data Transparency},
@@ -470,13 +707,81 @@ Jakob Rehof},
  year = {2022}
 }
 
-@inproceedings{dominik:kr2021,
- author = {Drexler, Dominik and Seipp, Jendrik and Geffner, Hector},
- booktitle = {{KR}},
- keywords = {Task-5.2-WP5},
- title = {Expressing and Exploiting the Common Subgoal Structure of Classical Planning Domains Using Sketches},
- url_paper = {arXiv preprint arXiv:2105.04250},
+@article{DBLP:journals/jlap/BoudouHT21,
+ author = {Joseph Boudou and
+Andreas Herzig and
+Nicolas Troquard},
+ doi = {10.1016/j.jlamp.2021.100683},
+ journal = {J. Log. Algebraic Methods Program.},
+ keywords = {WP5},
+ pages = {100683},
+ title = {Resource separation in dynamic logic of propositional assignments},
+ url = {https://doi.org/10.1016/j.jlamp.2021.100683},
+ volume = {121},
  year = {2021}
+}
+
+@article{DBLP:journals/simpa/ChiarielloMP22,
+ author = {Francesco Chiariello and
+Fabrizio Maria Maggi and
+Fabio Patrizi},
+ doi = {10.1016/j.simpa.2022.100435},
+ journal = {Softw. Impacts},
+ keywords = {WP5},
+ pages = {100435},
+ title = {A tool for compiling Declarative Process Mining problems in {ASP}},
+ url = {https://doi.org/10.1016/j.simpa.2022.100435},
+ url_paper = {https://doi.org/10.1016/j.simpa.2022.100435},
+ volume = {14},
+ year = {2022}
+}
+
+@article{DBLP:journals/simpa/GiacomoFMMP23,
+ author = {Giuseppe De Giacomo and
+Francesco Fuggitti and
+Fabrizio Maria Maggi and
+Andrea Marrella and
+Fabio Patrizi},
+ bibsource = {dblp computer science bibliography, https://dblp.org},
+ biburl = {https://dblp.org/rec/journals/simpa/GiacomoFMMP23.bib},
+ doi = {10.1016/j.simpa.2023.100505},
+ journal = {Softw. Impacts},
+ keywords = {WP5},
+ pages = {100505},
+ timestamp = {Sun, 06 Aug 2023 20:51:01 +0200},
+ title = {A tool for declarative Trace Alignment via automated planning},
+ url = {https://doi.org/10.1016/j.simpa.2023.100505},
+ url_paper = {https://doi.org/10.1016/j.simpa.2023.100505},
+ volume = {16},
+ year = {2023}
+}
+
+@inproceedings{drexler-et-al-kr2023,
+ author = {Dominik Drexler and Jendrik Seipp and Hector Geffner},
+ booktitle = {Proceedings of the Twentieth International Conference on Principles of
+Knowledge Representation and Reasoning (KR 2023)},
+ keywords = {WP5,A-level},
+ title = {Learning Hierarchical Policies by Iteratively Reducing the Width of
+Sketch Rules},
+ year = {2023}
+}
+
+@inproceedings{ecai2023cekmppssd,
+ author = {Remo Christen and Salom{\'e} Eriksson and Michael Katz and Christian Muise and Alice Petrov and Florian Pommerening and Jendrik Seipp and Silvan Sievers and David Speck},
+ booktitle = {ECAI},
+ keywords = {WP5,A-level,2+TAILOR-Partners,Outside-Europe},
+ title = {{PARIS}: Planning Algorithms for Reconfiguring Independent Sets},
+ year = {2023}
+}
+
+@inproceedings{ecai2023sfj,
+ author = {Javier Segovia-Aguas, Jonathan Ferrer-Mestres and Sergio Jim{\'e}nez},
+ booktitle = {{ECAI}},
+ keywords = {WP5,A-level,Outside-Europe},
+ title = {Synthesis of Procedural Models for Deterministic Transition Systems},
+ url_code = {https://github.com/jsego/bfgp-pp},
+ url_paper = {https://arxiv.org/pdf/2307.14368.pdf},
+ year = {2023}
 }
 
 @article{fgcs2021odet,
@@ -486,7 +791,7 @@ Montserrat Esta{\~{n}}ol and
 Ernest Teniente},
  doi = {10.1016/j.future.2020.11.018},
  journal = {{FGCS}},
- keywords = {Task-5.1-WP5},
+ keywords = {WP5},
  pages = {97--110},
  title = {Embedding Reactive Behavior into Artifact-centric Business Process
 Models},
@@ -495,20 +800,10 @@ Models},
  year = {2021}
 }
 
-@inproceedings{frances:aaai2021,
- author = {Franc{\`e}s, Guillem and Bonet, Blai and Geffner, Hector},
- booktitle = {{AAAI}},
- keywords = {Task-5.2-WP5},
- pages = {11801--11808},
- title = {Learning General Planning Policies from Small Examples Without Supervision},
- url_paper = {https://arxiv.org/pdf/2101.00692.pdf},
- year = {2021}
-}
-
 @article{fsn2021pp,
  author = {Parr, Thomas and Pezzulo, Giovanni},
  journal = {Frontiers in Systems Neuroscience},
- keywords = {Task-5.3-WP5},
+ keywords = {WP5},
  publisher = {Frontiers Media SA},
  title = {Understanding, Explanation, and Active Inference},
  volume = {15},
@@ -518,7 +813,7 @@ Models},
 @inproceedings{gandalf2021ztpv,
  author = {Shufang Zhu and Lucas M. Tabajara and Geguang Pu and Moshe Y. Vardi},
  booktitle = {{GandALF}},
- keywords = {Task-5.1-WP5},
+ keywords = {WP5,Outside-Europe},
  pages = {117--134},
  series = {{EPTCS}},
  title = {On the Power of Automata Minimization in Temporal Synthesis},
@@ -530,7 +825,7 @@ Models},
 @article{GMPRSW21,
  author = {Julian Gutierrez and Aniello Murano and Giuseppe Perelli and Sasha Rubin and Thomas Steeples and {Michael J.} Wooldridge},
  journal = {Acta Informatica},
- keywords = {Task-5.1-WP5},
+ keywords = {WP5},
  number = {6},
  pages = {585--610},
  title = {Equilibria for games with combined qualitative and quantitative objectives},
@@ -538,10 +833,20 @@ Models},
  year = {2021}
 }
 
+@inproceedings{hoeft-et-al-ecai2023,
+ author = {Paul H{\"o}ft and David Speck and Jendrik Seipp},
+ booktitle = {ECAI},
+ keywords = {WP5,A-level},
+ publisher = {IOS Press},
+ title = {Sensitivity Analysis for Saturated Post-hoc Optimization in
+Classical Planning},
+ year = {2023}
+}
+
 @inproceedings{icaps2021bkh,
  author = {Clemens B{\"u}chner and Thomas Keller and Malte Helmert},
  booktitle = {{ICAPS}},
- keywords = {Task-5.3-WP5},
+ keywords = {WP5,A-level},
  title = {Exploiting Cyclic Dependencies in Landmark Heuristics},
  url_paper = {https://ai.dmi.unibas.ch/papers/buechner-et-al-icaps2021.pdf},
  year = {2021}
@@ -550,7 +855,7 @@ Models},
 @inproceedings{icaps2021cfph,
  author = {Augusto B. Corr{\^e}a and Guillem Franc{\`e}s and Florian Pommerening and Malte Helmert},
  booktitle = {{ICAPS}},
- keywords = {Task-5.3-WP5},
+ keywords = {WP5,2+TAILOR-Partners,A-level},
  title = {Delete-Relaxation Heuristics for Lifted Classical Planning},
  url_paper = {https://ai.dmi.unibas.ch/papers/correa-et-al-icaps2021.pdf},
  year = {2021}
@@ -559,7 +864,7 @@ Models},
 @inproceedings{icaps2021df,
  author = {{De Giacomo}, Giuseppe and Favorito, Marco},
  booktitle = {{ICAPS}},
- keywords = {Task-5.1-WP5},
+ keywords = {WP5,A-level},
  title = {Compositional Approach to Translate LTLf/LDLf into Deterministic Finite Automata},
  url_paper = {https://whitemech.github.io/papers/2021/icaps2021df.pdf},
  volume = {14},
@@ -567,9 +872,9 @@ Models},
 }
 
 @inproceedings{icaps2021dss,
- author = {Dominik Drexler, Jendrik Seipp and David Speck},
+ author = {Dominik Drexler and Jendrik Seipp and David Speck},
  booktitle = {{ICAPS}},
- keywords = {Task-5.3-WP5},
+ keywords = {WP5,2+TAILOR-Partners,A-level},
  pages = {131--139},
  title = {Subset-Saturated Transition Cost Partitioning},
  url_paper = {https://ai.dmi.unibas.ch/papers/drexler-et-al-icaps2021.pdf},
@@ -577,9 +882,9 @@ Models},
 }
 
 @inproceedings{icaps2021fom,
- author = {Ramon {Fraga Pereira}, Nir Oren, Felipe Meneguzzi},
+ author = {Ramon {Fraga Pereira} and Nir Oren and Felipe Meneguzzi},
  booktitle = {{ICAPS}, Journal Track},
- keywords = {Task-5.2-WP5},
+ keywords = {WP5},
  title = {Landmark-Based Approaches for Goal Recognition as Planning},
  url_paper = {https://whitemech.github.io/papers/2021/icaps2021fom.pdf},
  year = {2021}
@@ -588,16 +893,27 @@ Models},
 @inproceedings{icaps2021pkhssh,
  author = {Florian Pommerening and Thomas Keller and Valentina Halasi and Jendrik Seipp and Silvan Sievers and Malte Helmert},
  booktitle = {{ICAPS}},
- keywords = {Task-5.3-WP5},
+ keywords = {WP5,2+TAILOR-Partners,A-level},
  title = {Dantzig-Wolfe Decomposition for Cost Partitioning},
  url_paper = {https://ai.dmi.unibas.ch/papers/pommerening-et-al-icaps2021.pdf},
+ year = {2021}
+}
+
+@inproceedings{icaps2021rbsg,
+ author = {Rodriguez, Ivan D and Bonet, Blai and Sardi{\~n}a, Sebastian and Geffner, Hector},
+ booktitle = {{ICAPS}},
+ keywords = {WP5,A-level,Outside-Europe},
+ pages = {290--298},
+ title = {Flexible {FOND} Planning with Explicit Fairness Assumptions},
+ url_paper = {https://ojs.aaai.org/index.php/ICAPS/article/view/15973/15784},
+ volume = {31},
  year = {2021}
 }
 
 @inproceedings{icaps2021s,
  author = {Jendrik Seipp},
  booktitle = {{ICAPS}},
- keywords = {Task-5.3-WP5},
+ keywords = {WP5,A-level},
  title = {Online Saturated Cost Partitioning for Classical Planning},
  url_paper = {https://ai.dmi.unibas.ch/papers/seipp-icaps2021.pdf},
  year = {2021}
@@ -606,7 +922,7 @@ Models},
 @inproceedings{icaps2021sjj,
  author = {Javier Segovia-Aguas and Sergio Jim{\'e}nez and Anders Jonsson},
  booktitle = {{ICAPS}},
- keywords = {Task-5.2-WP5},
+ keywords = {WP5,A-level},
  pages = {569--577},
  title = {Generalized Planning as Heuristic Search},
  url_code = {https://zenodo.org/record/4600833#.YK5N5nUzZH4},
@@ -618,7 +934,7 @@ Models},
 @inproceedings{icaps2021slrs,
  author = {Anubhav Singh and Nir Lipovetzky and Miquel Ramirez and Javier Segovia-Aguas},
  booktitle = {{ICAPS}},
- keywords = {Task-5.2-WP5},
+ keywords = {WP5,A-level,Outside-Europe},
  pages = {349--357},
  title = {Approximate Novelty Search},
  url_paper = {https://ojs.aaai.org/index.php/ICAPS/article/view/15980/15791},
@@ -629,7 +945,7 @@ Models},
 @inproceedings{icaps2021tss,
  author = {{\'A}lvaro Torralba and Jendrik Seipp and Silvan Sievers},
  booktitle = {{ICAPS}},
- keywords = {Task-5.3-WP5},
+ keywords = {WP5,2+TAILOR-Partners,A-level},
  title = {Automatic Instance Generation for Classical Planning},
  url_paper = {https://ai.dmi.unibas.ch/papers/torralba-et-al-icaps2021.pdf},
  year = {2021}
@@ -638,7 +954,7 @@ Models},
 @inproceedings{icaps2022ceph,
  author = {Remo Christen and Salom{\'e} Eriksson and Florian Pommerening and Malte Helmert},
  booktitle = {ICAPS},
- keywords = {Task-5.3-WP5},
+ keywords = {WP5,A-level},
  pages = {44--52},
  title = {Detecting Unsolvability Based on Separating Functions},
  url_paper = {https://ai.dmi.unibas.ch/papers/christen-et-al-icaps2022.pdf},
@@ -648,7 +964,7 @@ Models},
 @inproceedings{icaps2022cs,
  author = {Augusto B. Corr{\^e}a and Jendrik Seipp},
  booktitle = {{ICAPS}},
- keywords = {Task-5.3-WP5},
+ keywords = {WP5,A-level,2+TAILOR-Partners},
  pages = {11--15},
  title = {Best-First Width Search for Lifted Classical Planning},
  year = {2022}
@@ -657,7 +973,7 @@ Models},
 @inproceedings{icaps2022dsg,
  author = {Dominik Drexler and Jendrik Seipp and Hector Geffner},
  booktitle = {{ICAPS}},
- keywords = {Task-5.2-WP5},
+ keywords = {WP5,A-level},
  note = {To appear},
  title = {Learning Sketches for Decomposing Planning Problems into Subproblems of Bounded Width},
  year = {2022}
@@ -666,7 +982,7 @@ Models},
 @inproceedings{icaps2022fgthh,
  author = {Patrick Ferber and Florian Gei{\ss}er and Felipe Trevizan and Malte Helmert and Joerg Hoffmann},
  booktitle = {ICAPS},
- keywords = {Task-5.3-WP5},
+ keywords = {WP5,Outside-Europe,A-level},
  pages = {583--587},
  title = {Neural Network Heuristic Functions for Classical Planning: Bootstrapping and Comparison to Other Methods},
  url_paper = {https://ai.dmi.unibas.ch/papers/ferber-et-al-icaps2022.pdf},
@@ -676,7 +992,7 @@ Models},
 @inproceedings{icaps2022fmgd,
  author = {Ramon {Fraga Pereira}, Frederico Messa, Andre {Grahl Pereira}, Giuseppe {De Giacomo}},
  booktitle = {{ICAPS}},
- keywords = {Task-5.3-WP5},
+ keywords = {WP5,A-level,Outside-Europe},
  note = {To appear},
  title = {Iterative Depth-First Search for Fully Observable Non-Deterministic Planning},
  year = {2022}
@@ -685,17 +1001,27 @@ Models},
 @inproceedings{icaps2022hsrc,
  author = {Malte Helmert and Silvan Sievers and Alexander Rovner and Augusto B. Corr{\^e}a},
  booktitle = {ICAPS},
- keywords = {Task-5.3-WP5},
+ keywords = {WP5,A-level},
  pages = {124--133},
  title = {On the Complexity of Heuristic Synthesis for Satisficing Classical Planning: Potential Heuristics and Beyond},
  url_paper = {https://ai.dmi.unibas.ch/papers/helmert-et-al-icaps2022.pdf},
  year = {2022}
 }
 
+@inproceedings{icaps2022kpkr,
+ author = {Thorsten Kl{\"{o}}{\ss}ner and Florian Pommerening and Thomas Keller and Gabriele R{\"{o}}ger},
+ booktitle = {ICAPS},
+ keywords = {WP5,A-level},
+ pages = {193--202},
+ title = {Cost Partitioning Heuristics for Stochastic Shortest Path Problems},
+ url_paper = {https://ai.dmi.unibas.ch/papers/kloessner-et-al-icaps2022.pdf},
+ year = {2022}
+}
+
 @inproceedings{icaps2022sfefghhswch,
  author = {Marcel Steinmetz and Daniel Fi{\v{s}}er and Hasan Ferit Eniser and Patrick Ferber and Timo Gros and Philippe Heim and Daniel H{\"{o}}ller and Xandra Schuler and Valentin W{\"{u}}stholz and Maria Christakis and Joerg Hoffmann},
  booktitle = {ICAPS},
- keywords = {Task-5.3-WP5},
+ keywords = {WP5,A-level},
  pages = {353--361},
  title = {Debugging a Policy: Automatic Action-Policy Testing in AI Planning},
  url_paper = {https://ai.dmi.unibas.ch/papers/steinmetz-et-al-icaps2022.pdf},
@@ -705,7 +1031,7 @@ Models},
 @inproceedings{icaps2022ss,
  author = {David Speck and Jendrik Seipp},
  booktitle = {{ICAPS}},
- keywords = {Task-5.3-WP5},
+ keywords = {WP5,A-level},
  pages = {348--352},
  title = {New Refinement Strategies for Cartesian Abstractions},
  url_paper = {https://rlplab.com/papers/speck-seipp-icaps2022.pdf},
@@ -715,20 +1041,31 @@ Models},
 @inproceedings{icaps2022vms,
  author = {Julian {von Tschammer} and Robert Mattmüller and David Speck},
  booktitle = {{ICAPS}},
- keywords = {Task-5.3-WP5},
+ keywords = {WP5,A-level},
  pages = {380--384},
  title = {Loopless Top-k Planning},
  url_paper = {https://rlplab.com/papers/vontschammer-et-al-icaps2022.pdf},
  year = {2022}
 }
 
-@inproceedings{iclp2022cmp,
- author = {Francesco Chiariello and {Fabrizio Maria} Maggi and Fabio Patrizi},
- booktitle = {Proceedings of the 38th International Conference on Logic Programming (Technical Communications) ({ICLP})},
- keywords = {Task-5.1-WP5},
- publisher = {Electronic Proceedings in Theoretical Computer Science (EPTCS)},
- title = {{ASP}-Based Declarative Process Mining (Extended Abstract)},
- year = {2022}
+@inproceedings{icaps2023bsks,
+ author = {Gregor Behnke and David Speck and Michael Katz and Shirin Sohrabi},
+ booktitle = {ICAPS},
+ keywords = {WP5,A-level},
+ pages = {42--51},
+ title = {On Partial Satisfaction Planning with Total-Order HTNs},
+ url_paper = {https://rlplab.com/papers/behnke-et-al-icaps2023.pdf},
+ year = {2023}
+}
+
+@inproceedings{icaps2023shgs,
+ author = {David Speck and Paul H{\"o}ft and Daniel Gnad and Jendrik Seipp},
+ booktitle = {ICAPS},
+ keywords = {WP5,A-level},
+ pages = {411--416},
+ title = {Finding Matrix Multiplication Algorithms with Classical Planning},
+ url_paper = {https://rlplab.com/papers/speck-et-al-icaps2023.pdf},
+ year = {2023}
 }
 
 @inproceedings{icpm2021abfmmp,
@@ -739,7 +1076,7 @@ Alessio Fiorenza and
 Andrea Marrella and
 Fabio Patrizi},
  booktitle = {{ICPM}},
- keywords = {Task-5.1-WP5},
+ keywords = {WP5,WP6},
  pages = {48--55},
  publisher = {{IEEE}},
  title = {Discovering Declarative Process Model Behavior from Event Logs via
@@ -750,7 +1087,7 @@ Model Learning},
 @inproceedings{ijcai2021adr,
  author = {Benjamin Aminof and Giuseppe {De Giacomo} and Sasha Rubin},
  booktitle = {{IJCAI}},
- keywords = {Task-5.1-WP5},
+ keywords = {WP5,A-level,Outside-Europe},
  title = {Best-Effort Synthesis: Doing Your Best Is Not Harder Than Giving Up},
  year = {2021}
 }
@@ -758,7 +1095,7 @@ Model Learning},
 @inproceedings{ijcai2021cdln,
  author = {Marco Console and Giuseppe {De Giacomo} and Maurizio Lenzerini and Manuel Namici},
  booktitle = {{IJCAI}},
- keywords = {Task-5.1-WP5, WP4},
+ keywords = {WP5,WP4,A-level},
  title = {Intensional and Extensional Views in {DL-Lite} Ontologies},
  year = {2021}
 }
@@ -766,7 +1103,7 @@ Model Learning},
 @inproceedings{ijcai2021ddmvz,
  author = {Giuseppe {De Giacomo} and Antonio {Di Stasio} and Lucas M. Tabajara and Moshe Vardi and Shufang Zhu},
  booktitle = {{IJCAI}},
- keywords = {Task-5.1-WP5},
+ keywords = {WP5,A-level,Outside-Europe},
  title = {Finite-Trace and Generalized-Reactivity Specifications in Temporal Synthesis},
  year = {2021}
 }
@@ -774,42 +1111,15 @@ Model Learning},
 @inproceedings{ijcai2021dfmp,
  author = {Giuseppe {De Giacomo} and Paolo Felli and Marco Montali and Giuseppe Perelli},
  booktitle = {{IJCAI}},
- keywords = {Task-5.1-WP5},
+ keywords = {WP5,A-level,2+TAILOR-Partners},
  title = {{HyperLDLf}: a Logic for Checking Properties of Finite Traces Process Logs},
- year = {2021}
-}
-
-@inproceedings{ijcai2021hhl,
- author = {Daniel Habering and
-Till Hofmann and
-Gerhard Lakemeyer},
- booktitle = {{IJCAI}},
- keywords = {Task-5.3-WP5,Task-5.4-WP5},
- pages = {1908--1914},
- publisher = {ijcai.org},
- title = {Using Platform Models for a Guided Explanatory Diagnosis Generation
-for Mobile Robots},
- url_paper = {https://www.ijcai.org/proceedings/2021/0263.pdf},
- year = {2021}
-}
-
-@inproceedings{ijcai2021ll,
- author = {Daxin Liu and
-Gerhard Lakemeyer},
- booktitle = {{IJCAI}},
- keywords = {Task-5.1-WP5},
- pages = {1951--1958},
- publisher = {ijcai.org},
- title = {Reasoning about Beliefs and Meta-Beliefs by Regression in an Expressive
-Probabilistic Action Logic},
- url_paper = {https://www.ijcai.org/proceedings/2021/0269.pdf},
  year = {2021}
 }
 
 @inproceedings{ijcai2021lssgt,
  author = {Leonardo Lamanna and Alessandro Saetti and Luciano Serafini and Alfonso E. Gerevini and Paolo Traverso},
  booktitle = {{IJCAI}},
- keywords = {Task-5.4-WP5},
+ keywords = {WP5,A-level,2+TAILOR-Partners},
  title = {Online Learning of Action Models for {PDDL} Planning},
  year = {2021}
 }
@@ -817,7 +1127,7 @@ Probabilistic Action Logic},
 @inproceedings{ijcai2021mf,
  author = {Felipe Meneguzzi and Ramon {Fraga Pereira}},
  booktitle = {{IJCAI}},
- keywords = {Task-5.1-WP5},
+ keywords = {WP5,A-level,Outside-Europe},
  title = {A Survey on Goal Recognition as Planning},
  url_paper = {https://whitemech.github.io/papers/2021/ijcai2021mf.pdf},
  year = {2021}
@@ -826,39 +1136,34 @@ Probabilistic Action Logic},
 @inproceedings{ijcai2021rd,
  author = {Alessandro Ronca and Giuseppe {De Giacomo}},
  booktitle = {{IJCAI}},
- keywords = {Task-5.2-WP5},
+ keywords = {WP5,A-level},
  title = {Efficient {PAC} Reinforcement Learning in Regular Decision Processes},
+ year = {2021}
+}
+
+@inproceedings{ijcai2021sfs,
+ author = {St{\aa}hlberg, Simon and Franc{\`e}s, Guillem and Seipp, Jendrik},
+ booktitle = {{IJCAI}},
+ keywords = {WP5,A-level},
+ pages = {4175--4181},
+ title = {Learning Generalized Unsolvability Heuristics for Classical Planning},
  year = {2021}
 }
 
 @inproceedings{ijcai2021sw,
  author = {Silvan Sievers and Martin Wehrle},
  booktitle = {{IJCAI}},
- keywords = {Task-5.3-WP5},
+ keywords = {WP5,A-level},
  pages = {4167--4174},
  title = {On Weak Stubborn Sets in Classical Planning},
  url_paper = {https://ai.dmi.unibas.ch/papers/sievers-wehrle-ijcai2021.pdf},
  year = {2021}
 }
 
-@inproceedings{ijcai2021vhl,
- author = {Tarik Viehmann and
-Till Hofmann and
-Gerhard Lakemeyer},
- booktitle = {{IJCAI}},
- keywords = {Task-5.3-WP5,Task-5.4-WP5},
- pages = {2083--2089},
- publisher = {ijcai.org},
- title = {Transforming Robotic Plans with Timed Automata to Solve Temporal Platform
-Constraints},
- url_paper = {https://www.ijcai.org/proceedings/2021/0287.pdf},
- year = {2021}
-}
-
 @inproceedings{ijcai2022fcsk,
- author = {Patrick Ferber, Liat Cohen, Jendrik Seipp and Thomas Keller},
+ author = {Patrick Ferber and Liat Cohen and Jendrik Seipp and Thomas Keller},
  booktitle = {IJCAI},
- keywords = {Task-5.3-WP5},
+ keywords = {WP5,2+TAILOR-Partners,A-level},
  pages = {4740--4746},
  title = {Learning and Exploiting Progress States in Greedy Best-First Search},
  url_paper = {https://ai.dmi.unibas.ch/papers/ferber-et-al-ijcai2022.pdf},
@@ -872,7 +1177,7 @@ Nadjib Lazaar and
 Arnaud Gotlieb},
  booktitle = { {IJCAI}},
  doi = {10.24963/ijcai.2022/260},
- keywords = { Task-5.3-WP5, WP4},
+ keywords = {WP5,WP4,A-level},
  title = {Automated Program Analysis: Revisiting Precondition Inference through
 Constraint Acquisition},
  url_paper = {https://doi.org/10.24963/ijcai.2022/260},
@@ -885,39 +1190,29 @@ Gabriel {Paludo Licks} and
 Giuseppe {De Giacomo}},
  booktitle = {{IJCAI}},
  doi = {10.24963/ijcai.2022/473},
- keywords = {Task-5.1-WP5},
+ keywords = {WP5,A-level},
  title = {Markov Abstractions for {PAC} Reinforcement Learning in Non-{M}arkov
 Decision Processes},
+ year = {2022}
+}
+
+@inproceedings{ijcaiAinetoORSS22,
+ author = {Diego Aineto and Eva Onaindia and Miquel Ram{\'{\i}}rez and Enrico Scala and Ivan Serina},
+ booktitle = {{IJCAI}},
+ keywords = {WP5,A-level,Outside-Europe},
+ pages = {4567--4573},
+ publisher = {ijcai.org},
+ title = {Explaining the Behaviour of Hybrid Systems with {PDDL+} Planning},
  year = {2022}
 }
 
 @inproceedings{italia2022dfmls,
  author = {Giuseppe {De Giacomo} and Marco Favorito and Massimo Mecella and Francesco Leotta and Luciana Silo},
  booktitle = {{ITAL-IA} Workshop},
- keywords = {Task-5.5-WP5},
+ keywords = {WP5},
  title = {Digital Twins Composition via Markov Decision Processes},
  url_paper = {https://whitemech.github.io/papers/2022/italia2022dfmls.pdf},
  year = {2022}
-}
-
-@inproceedings{ivan:icaps2021,
- author = {Rodriguez, Ivan D and Bonet, Blai and Sardi{\~n}a, Sebastian and Geffner, Hector},
- booktitle = {{ICAPS}},
- keywords = {Task-5.2-WP5},
- pages = {290--298},
- title = {Flexible {FOND} Planning with Explicit Fairness Assumptions},
- url_paper = {https://ojs.aaai.org/index.php/ICAPS/article/view/15973/15784},
- volume = {31},
- year = {2021}
-}
-
-@inproceedings{ivan:kr2021,
- author = {Rodriguez, Ivan D and Bonet, Blai and Romero, Javier and Geffner, Hector},
- booktitle = {{KR}},
- keywords = {Task-5.2-WP5},
- title = {Learning First-Order Representations for Planning from Black-Box States: New Results},
- url_paper = {arXiv preprint arXiv:2105.10830},
- year = {2021}
 }
 
 @article{jair2021dors,
@@ -927,7 +1222,7 @@ Riccardo Rosati and
 Domenico Fabio Savo},
  doi = {10.1613/jair.1.12414},
  journal = {{JAIR}},
- keywords = {Task-5.1-WP5, WP4},
+ keywords = {WP5,WP4,A-level},
  pages = {1335--1371},
  title = {Instance-Level Update in DL-Lite Ontologies through First-Order Rewriting},
  url_paper = {https://whitemech.github.io/papers/2021/jair2021dors.pdf},
@@ -938,7 +1233,7 @@ Domenico Fabio Savo},
 @article{jair2021sh,
  author = {Silvan Sievers and Malte Helmert},
  journal = {{JAIR}},
- keywords = {Task-5.3-WP5},
+ keywords = {WP5,A-level},
  pages = {781--883},
  title = { Merge-and-Shrink: A Compositional Theory of Transformations of Factored Transition Systems},
  url_paper = {https://ai.dmi.unibas.ch/papers/sievers-helmert-jair2021.pdf},
@@ -946,24 +1241,20 @@ Domenico Fabio Savo},
  year = {2021}
 }
 
-@article{jlamp2021bht,
- author = {Joseph Boudou and
-Andreas Herzig and
-Nicolas Troquard},
- doi = {10.1016/j.jlamp.2021.100683},
- journal = {J. Log. Algebraic Methods Program.},
- keywords = { Task-5.1-WP5},
- pages = {100683},
- title = {Resource separation in dynamic logic of propositional assignments},
- url = {https://doi.org/10.1016/j.jlamp.2021.100683},
- volume = {121},
- year = {2021}
+@inproceedings{kloessner-et-al-ecai2023,
+ author = {Thorsten Kl{\"o}{\ss}ner and Jendrik Seipp and Marcel Steinmetz},
+ booktitle = {Proceedings of the 26th {European} Conference on {Artificial}
+{Intelligence} ({ECAI} 2023)},
+ keywords = {WP5,A-level},
+ title = {{Cartesian} Abstractions and Saturated Cost Partitioning in
+Probabilistic Planning},
+ year = {2023}
 }
 
 @inproceedings{kr2021adlmr,
  author = {Benjamin Aminof and Giuseppe {De Giacomo} and Alessio Lomuscio and Aniello Murano and Sasha Rubin},
  booktitle = {{KR}},
- keywords = {Task-5.1-WP5},
+ keywords = {WP5,A-level,Outside-Europe},
  title = {Synthesizing {Best-Effort} Strategies under Multiple Environment Specifications },
  year = {2021}
 }
@@ -971,7 +1262,7 @@ Nicolas Troquard},
 @inproceedings{kr2021ajo,
  author = {Diego Aineto and Sergio Jim{\'{e}}nez and Eva Onaindia},
  booktitle = {{KR}},
- keywords = {Task-5.3-WP5},
+ keywords = {WP5,A-level},
  pages = {22--31},
  title = {Generalized Temporal Inference via Planning},
  url_paper = {https://doi.org/10.24963/kr.2021/3},
@@ -981,7 +1272,7 @@ Nicolas Troquard},
 @inproceedings{kr2021ddpz,
  author = {Giuseppe {De Giacomo} and Antonio {Di Stasio} and Giuseppe Perelli and Shufang Zhu},
  booktitle = {{KR}},
- keywords = {Task-5.1-WP5},
+ keywords = {WP5,A-level},
  title = {Synthesis with Mandatory Stop Actions},
  year = {2021}
 }
@@ -989,7 +1280,7 @@ Nicolas Troquard},
 @inproceedings{kr2021dl,
  author = {Giuseppe {De Giacomo} and Yves {Lesp{\'{e}}rance}},
  booktitle = {{KR}},
- keywords = {Task-5.1-WP5},
+ keywords = {WP5,A-level,Outside-Europe},
  title = {The Nondeterministic Situation Calculus},
  year = {2021}
 }
@@ -997,32 +1288,26 @@ Nicolas Troquard},
 @inproceedings{kr2021dmpp,
  author = {Giuseppe {De Giacomo} and Aniello Murano and Fabio Patrizi and Giuseppe Perelli},
  booktitle = {{KR}},
- keywords = {Task-5.1-WP5},
+ keywords = {WP5,A-level},
  title = {Timed Trace Alignment with Metric Temporal Logic over Finite Traces},
  year = {2021}
 }
 
-@inproceedings{kr2021hmp,
- author = {Andreas Herzig and
-Fr{\'{e}}d{\'{e}}ric Maris and
-Elise Perrotin},
+@inproceedings{kr2021dsg,
+ author = {Drexler, Dominik and Seipp, Jendrik and Geffner, Hector},
  booktitle = {{KR}},
- doi = {10.24963/kr.2021/68},
- keywords = { Task-5.1-WP5},
- pages = {676--680},
- title = {A Dynamic Epistemic Logic with Finite Iteration and Parallel Composition},
- url = {https://proceedings.kr.org/2021/68/kr2021-0068-herzig-et-al.pdf},
+ keywords = {WP5,A-level},
+ title = {Expressing and Exploiting the Common Subgoal Structure of Classical Planning Domains Using Sketches},
+ url_paper = {arXiv preprint arXiv:2105.04250},
  year = {2021}
 }
 
-@inproceedings{kr2021hy,
- author = {Andreas Herzig and
-Antonio Yuste{-}Ginel},
+@inproceedings{kr2021rbrg,
+ author = {Rodriguez, Ivan D and Bonet, Blai and Romero, Javier and Geffner, Hector},
  booktitle = {{KR}},
- keywords = {WP6},
- pages = {681--685},
- title = {On the Epistemic Logic of Incomplete Argumentation Frameworks},
- url = {https://doi.org/10.24963/kr.2021/69},
+ keywords = {WP5,A-level,Outside-Europe},
+ title = {Learning First-Order Representations for Planning from Black-Box States: New Results},
+ url_paper = {arXiv preprint arXiv:2105.10830},
  year = {2021}
 }
 
@@ -1033,24 +1318,15 @@ Alessandro Saetti and
 Alfonso Gerevini and
 Paolo Traverso},
  booktitle = {{KR}},
- keywords = {Task-5.4-WP5},
+ keywords = {WP5,A-level},
  title = {Online Grounding of Symbolic Planning Domains in Unknown Environments},
  url_paper = {https://proceedings.kr.org/2022/53/kr2022-0053-lamanna-et-al.pdf},
  year = {2022}
 }
 
-@article{ml2021yrd,
- author = {Yang, Wen-Chi and Raskin, Jean-François and De Raedt, Luc},
- journal = {Machine Learning},
- keywords = {Task-5.3-WP5},
- publisher = {Springer Verlag},
- title = {Lifted Model Checking for Relational MDPs},
- year = {2021}
-}
-
 @inproceedings{pmai2022ijcai,
  author = {{De Giacomo}, Giuseppe and Favorito, Marco and Leotta, Francesco and Mecella, Massimo and Silo, Luciana},
- keywords = {Task-5.5-WP5},
+ keywords = {WP5},
  series = {{CEUR}},
  title = {Modeling resilient cyber-physical processes and their composition from digital twins via Markov Decision Processes},
  workshop = {{PMAI} Workshop},
@@ -1060,7 +1336,7 @@ Paolo Traverso},
 @inproceedings{prl2021dfip,
  author = {Giuseppe {De Giacomo} and Marco Favorito and Luca Iocchi and Fabio Patrizi},
  booktitle = {{PRL} Workshop},
- keywords = {Task-5.2-WP5},
+ keywords = {WP5},
  title = {{Domain-Independent} Reward Machines for Modular Integration of Planning and Learning},
  year = {2021}
 }
@@ -1068,7 +1344,7 @@ Paolo Traverso},
 @inproceedings{prl2021rd,
  author = {Alessandro Ronca and Giuseppe {De Giacomo}},
  booktitle = {{PRL} Workshop},
- keywords = {Task-5.2-WP5},
+ keywords = {WP5,A-level},
  title = {Efficient {PAC} Reinforcement Learning in Regular Decision Processes},
  year = {2021}
 }
@@ -1081,24 +1357,15 @@ Roberto Capobianco and
 Daniele Nardi and
 Giuseppe {De Giacomo}},
  booktitle = {{PRL} Workshop},
- keywords = {Task-5.2-WP5},
+ keywords = {WP5},
  title = {Learning a Symbolic Planning Domain through the Interaction with Continuous Environments},
  year = {2021}
-}
-
-@inproceedings{prl2022bsshls,
- author = {Andr{\'e} Biedenkapp and David Speck and Silvan Sievers and Frank Hutter and Marius Lindauer and Jendrik Seipp},
- booktitle = {{PRL} Workshop},
- keywords = {Task-5.3-WP5},
- title = {Learning Domain-Independent Policies for Open List Selection},
- url_paper = {https://rlplab.com/papers/biedenkapp-et-al-icaps2022wsprl.pdf},
- year = {2022}
 }
 
 @inproceedings{prl22exploitinglevels,
  author = {Roberto Cipollone and Giuseppe {De Giacomo} and Marco Favorito and Luca Iocchi and Fabio Patrizi},
  booktitle = {{PRL} Workshop},
- keywords = {Task-5.1-WP5},
+ keywords = {WP5},
  title = {Exploiting Multiple Levels of Abstractions in Episodic RL via Reward Shaping},
  url_paper = {https://prl-theworkshop.github.io/prl2022-ijcai/papers/PRL2022_paper_24.pdf},
  year = {2022}
@@ -1110,7 +1377,7 @@ David Bergstr{\"{o}}m and
 Andreas Norrstig and
 Fredrik Heintz},
  journal = {{IEEE} Robotics and Automation Letters},
- keywords = {Task-5.2-WP5},
+ keywords = {WP3,WP4,WP5},
  number = {3},
  pages = {4385--4392},
  title = {Enhancing Lattice-Based Motion Planning With Introspective Learning
@@ -1120,13 +1387,22 @@ and Reasoning},
  year = {2021}
 }
 
+@inproceedings{salerno-et-al-kr2023,
+ author = {Mauricio Salerno and Raquel Fuentetaja and Jendrik Seipp},
+ booktitle = {Proceedings of the Twentieth International Conference on Principles of
+Knowledge Representation and Reasoning (KR 2023)},
+ keywords = {WP5,A-level},
+ title = {Eliminating Redundant Actions from Plans using Classical Planning},
+ year = {2023}
+}
+
 @inproceedings{segovia2022computing,
  author = {Segovia-Aguas, Javier and Jiménez Celorrio, Sergio and Jonsson, Anders},
  booktitle = {Proceedings of the Thirty-First International Joint Conference on
 Artificial Intelligence, {IJCAI-22}},
  doi = {10.24963/ijcai.2022/746},
  editor = {Lud De Raedt},
- keywords = {Task-5.2-WP5},
+ keywords = {WP5,A-level},
  month = {7},
  note = {Sister Conferences Best Papers},
  pages = {5334--5338},
@@ -1139,7 +1415,7 @@ Artificial Intelligence, {IJCAI-22}},
 @inproceedings{segovia2022scaling,
  author = {Segovia-Aguas, Javier and Celorrio, Sergio Jim{\'e}nez and Sebasti{\'a}, Laura and Jonsson, Anders},
  booktitle = {Proceedings of the International Symposium on Combinatorial Search},
- keywords = {Task-5.2-WP5},
+ keywords = {WP5},
  number = {1},
  pages = {171--179},
  title = {Scaling-up generalized planning as heuristic search with landmarks},
@@ -1150,25 +1426,16 @@ Artificial Intelligence, {IJCAI-22}},
 @inproceedings{simon:icaps2022,
  author = {St{\aa}hlberg, Simon and Bonet, Blai and Geffner, Hector},
  booktitle = {{ICAPS}},
- keywords = {Task-5.2-WP5},
+ keywords = {WP5,A-level},
  pages = {629--637},
  title = {Learning General Optimal Policies with Graph Neural Networks: Expressive Power, Transparency, and Limits},
  year = {2022}
 }
 
-@inproceedings{simon:ijcai2021,
- author = {St{\aa}hlberg, Simon and Franc{\`e}s, Guillem and Seipp, Jendrik},
- booktitle = {{IJCAI}},
- keywords = {Task-5.2-WP5},
- pages = {4175--4181},
- title = {Learning Generalized Unsolvability Heuristics for Classical Planning},
- year = {2021}
-}
-
 @inproceedings{simon:kr2022,
  author = {St{\aa}hlberg, Simon and Bonet, Blai and Geffner, Hector},
  booktitle = {{KR}},
- keywords = {Task-5.2-WP5},
+ keywords = {WP5,A-level},
  title = {Learning Generalized Policies without Supervision Using GNNs},
  year = {2022}
 }
@@ -1176,7 +1443,7 @@ Artificial Intelligence, {IJCAI-22}},
 @inproceedings{socs2022hfbhh,
  author = {Daniel Heller and Patrick Ferber and Julian Bitterwolf and Matthias Hein and Joerg Hoffmann},
  booktitle = {SoCS},
- keywords = {Task-5.3-WP5},
+ keywords = {WP5},
  pages = {223--228},
  title = {Neural Network Heuristic Functions: Taking Confidence into Account},
  url_paper = {https://ai.dmi.unibas.ch/papers/heller-et-al-socs2022.pdf},
@@ -1185,18 +1452,28 @@ Artificial Intelligence, {IJCAI-22}},
 
 @inproceedings{socs2022hs,
  author = {Kilian Hu and David Speck},
- booktitle = {{SoCS}},
- keywords = {Task-5.3-WP5},
+ booktitle = {SoCS},
+ keywords = {WP5},
  pages = {91--99},
  title = {On Bidirectional Heuristic Search in Classical Planning: An Analysis of BAE*},
  url_paper = {https://rlplab.com/papers/hu-speck-socs2022.pdf},
  year = {2022}
 }
 
+@inproceedings{socs2022sgt,
+ author = {Silvan Sievers and Daniel Gnad and {\'{A}}lvaro Torralba},
+ booktitle = {SOCS},
+ keywords = {WP5},
+ pages = {180--189},
+ title = {Additive Pattern Databases for Decoupled Search},
+ url_paper = {https://rlplab.com/papers/sievers-et-al-socs2022.pdf},
+ year = {2022}
+}
+
 @inproceedings{spark2021gfm,
  author = {Kin Max Gusmão, Ramon {Fraga Pereira}, Felipe Meneguzzi},
  booktitle = {{SPARK} Workshop ({ICAPS})},
- keywords = {Task-5.2-WP5},
+ keywords = {WP5},
  title = {Inferring Agents Preferences as Priors for Probabilistic Goal Recognition},
  url_paper = {https://whitemech.github.io/papers/2021/spark2021gfm.pdf},
  year = {2021}
@@ -1205,7 +1482,7 @@ Artificial Intelligence, {IJCAI-22}},
 @inproceedings{suarez2021automatic,
  author = {Su{\'a}rez-Hern{\'a}ndez, Alejandro and Andriella, Antonio and Taranovi{\'c}, Aleksandar and Segovia-Aguas, Javier and Torras, Carme and Aleny{\`a}, Guillem},
  booktitle = {2021 30th IEEE International Conference on Robot \& Human Interactive Communication (RO-MAN)},
- keywords = {Task-5.2-WP5},
+ keywords = {WP5},
  organization = {IEEE},
  pages = {139--146},
  title = {Automatic learning of cognitive exercises for socially assistive robotics},
@@ -1217,7 +1494,7 @@ Artificial Intelligence, {IJCAI-22}},
  doi = {10.1145/3439900},
  issn = {1529-3785},
  journal = {ACM Trans. Comput. Logic},
- keywords = {Task-5.1-WP5},
+ keywords = {WP5},
  number = {2},
  publisher = {Association for Computing Machinery},
  title = {Expressiveness and Nash Equilibrium in Iterated Boolean Games},
@@ -1226,3 +1503,29 @@ Artificial Intelligence, {IJCAI-22}},
  year = {2021}
 }
 
+@inproceedings{workshop/ewrl/Cipollone23,
+ author = {Roberto Cipollone and Anders Jonsson and Alessandro Ronca and Mohammad Sadegh Talebi},
+ booktitle = {European Workshop on Reinforcement Learning (EWRL)},
+ keywords = {WP5},
+ title = {{Beyond Markovian RL: Efficient Offline RL in Regular Decision Processes}},
+ url_paper = {https://openreview.net/pdf?id=fBaYBz8pUfk},
+ year = {2023}
+}
+
+@inproceedings{workshop/ewrl/Infante23,
+ author = {Guillermo Infante and Anders Jonsson and Vicen\c{c} G\'omez},
+ booktitle = {European Workshop on Reinforcement Learning (EWRL)},
+ keywords = {WP5},
+ title = {{Optimal Hierarchical Average-Reward Linearly-solvable Markov Decision Processes}},
+ url_paper = {https://openreview.net/pdf?id=fgKZNFAKt5},
+ year = {2023}
+}
+
+@article{YangWen-Chi2021LMCf,
+ author = {Yang, Wen-Chi and Raskin, Jean-François and De Raedt, Luc},
+ journal = {Machine Learning},
+ keywords = {WP5,WP4},
+ publisher = {Springer Verlag},
+ title = {Lifted Model Checking for Relational MDPs},
+ year = {2021}
+}


### PR DESCRIPTION
As you know I'm updating the bib file for all Tailor. So I have the global bib file, parsed and checked.
What I have done here is to take that file, filter for the WP5 keyword and paste all entries into this file.
Pros:
  - This will allow a easy and quick update for our WP (as well as any other). Filtering is easy and I have a little script for that.
  - Updates will be consistent in the future, if we continue to update the global bib file
Cons:
  - The global bib file does not store information about which paper is in which WP5 task. New papers won't have this information, and this overwrite will erase the old infomation about which task is which. Giuseppe said that it's OK if we don't have this information anyway. I didn't ask about this overwrite specifically, but I ask if I could just skip the missing information from new entries.

This overwrite removes 4 papers, which I'll add back by updating the global Tailor bib file, then filtering again once that file has settled (end of september)
Let me know what you think
